### PR TITLE
Linux build & hopper 4.3.30 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,19 @@ The target processor of this plugin is the **VPU**, not the QPU (which is docume
 
 As there is no official documentation for the VideoCore IV VPU, this work is based on various unofficial resources referenced below as well as some own research.
 
-#### BUILDING THE PLUGIN
+#### BUILDING THE PLUGIN (OS X)
 
 To build, clone or download the sources, then open the XCode project and build the plugin. Once built, double-click on the plugin. Alternatively, the plugin can be moved in the ~/Library/Application Support/Hopper/Plugins/v4/CPUs folder (that must be created, if needed).
+
+
+#### BUILDING THE PLUGIN (Linux)
+
+This version has been tested with the Linux SDK for Hopper 4.3.30. The following steps are required:
+
+    . <PATH_TO_HOPPER_SDK>/Linux/gnustep-Linux-x86_64/share/GNUstep/Makefiles/GNUstep.sh 
+    make HOPPER_INCLUDE_PATH=<PATH_TO_HOPPER_SDK>/include
+    ln -s `pwd`/VC4CPU.bundle ~/GNUstep/Library/ApplicationSupport/Hopper/PlugIns/v4/CPUs/VC4CPU.hopperCPU
+
 
 #### NOTE
 
@@ -26,8 +36,6 @@ This plugin tries to make full use of Hopper capabilities, but its edges are sti
 * This project is at an early stage and very little testing has been done,
 * Take disassembled vector operations with caution,
 * Code is not yet analyzed.
-
-This plugin was developed on OS X, it has not been tested on Linux. I don’t even know if plugins are supported on the Linux version of Hopper. If you manage to use it on Linux, please let me know.
 
 Most documentation used was found (or is referenced) [here](https://github.com/hermanhermitage/videocoreiv). The most useful source is the unofficial [VideoCore IV Programmers Manual](https://github.com/hermanhermitage/videocoreiv/wiki/VideoCore-IV-Programmers-Manual).
 

--- a/videocore iv/GNUmakefile
+++ b/videocore iv/GNUmakefile
@@ -1,0 +1,14 @@
+include $(GNUSTEP_MAKEFILES)/common.make
+
+HOPPER_INCLUDE_PATH=../external/Hopper/include
+
+COMMON_OBJC_FLAGS = -I$(HOPPER_INCLUDE_PATH) -DLINUX -Wno-format -fblocks -fobjc-nonfragile-abi -fobjc-arc
+
+BUNDLE_NAME = VC4CPU
+
+VC4CPU_OBJC_FILES = VC4Definition.m VC4Context.m VC4Disassembly.m
+
+VC4CPU_CFLAGS = 
+VC4CPU_OBJCFLAGS = $(COMMON_OBJC_FLAGS)
+
+include $(GNUSTEP_MAKEFILES)/bundle.make

--- a/videocore iv/VC4Context.h
+++ b/videocore iv/VC4Context.h
@@ -6,8 +6,6 @@
 //  Copyright © 2016 Pascal Werz. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
-
 #import <Hopper/Hopper.h>
 
 #import "VC4Definition.h"

--- a/videocore iv/VC4Context.m
+++ b/videocore iv/VC4Context.m
@@ -295,8 +295,6 @@
     return YES;
 }
 
-
-
 - (BOOL)instructionOnlyLoadsAddress:(DisasmStruct *)disasmStruct
 {
     if (disasmStruct->instruction.userData == VC4_INST_LEA)
@@ -305,6 +303,17 @@
 }
 
 
+- (BOOL)instructionManipulatesFloat:(DisasmStruct *)disasmStruct {
+	return NO; // FIXME
+}
+
+- (BOOL)instructionConditionsCPUModeAtTargetAddress:(DisasmStruct *)disasmStruct resultCPUMode:(uint8_t *)cpuMode {
+	return NO;
+}
+
+- (uint8_t)cpuModeForNextInstruction:(DisasmStruct *)disasmStruct {
+	return 0;
+}
 
 - (BOOL)instructionMayBeASwitchStatement:(DisasmStruct *)disasm
 {

--- a/videocore iv/VC4Definition.m
+++ b/videocore iv/VC4Definition.m
@@ -15,6 +15,9 @@
     return [VC4Context class];
 }
 
++ (int)sdkVersion {
+	return HOPPER_CURRENT_SDK_VERSION;
+}
 
 - (NSObject<CPUContext> *)buildCPUContextForFile:(NSObject<HPDisassembledFile> *)file
 {
@@ -28,7 +31,9 @@
     return @[@"VideoCore IV"];
 }
 
-
+- (NSString *)commandLineIdentifier {
+	return @"VC4";
+}
 
 - (NSArray *)cpuSubFamiliesForFamily:(NSString *)family
 {
@@ -149,21 +154,21 @@
 
 
 
-- (BOOL)registerIndexIsStackPointer:(NSUInteger)reg ofClass:(RegClass)reg_class
+- (BOOL)registerIndexIsStackPointer:(NSUInteger)reg ofClass:(RegClass)reg_class cpuMode:(uint8_t)cpuMode file:(NSObject<HPDisassembledFile> *)file
 {
     return reg_class == RegClass_GeneralPurposeRegister && reg == 25;
 }
 
 
 
-- (BOOL)registerIndexIsFrameBasePointer:(NSUInteger)reg ofClass:(RegClass)reg_class
+- (BOOL)registerIndexIsFrameBasePointer:(NSUInteger)reg ofClass:(RegClass)reg_class cpuMode:(uint8_t)cpuMode file:(NSObject<HPDisassembledFile> *)file
 {
     return NO;
 }
 
 
 
-- (BOOL)registerIndexIsProgramCounter:(NSUInteger)reg
+- (BOOL)registerIndexIsProgramCounter:(NSUInteger)reg cpuMode:(uint8_t)cpuMode file:(NSObject<HPDisassembledFile> *)file
 {
     return reg == 31;
 }
@@ -177,7 +182,7 @@
 
 
 
-- (NSString *)framePointerRegisterNameForFile:(NSObject<HPDisassembledFile> *)file {
+- (NSString *)framePointerRegisterNameForFile:(NSObject<HPDisassembledFile> *)file cpuMode:(uint8_t)cpuMode {
     return nil;
 }
 


### PR DESCRIPTION
This allows the plugin to be built under Linux for the Linux version of Hopper. I'm using a newer Hopper SDK, so I've also included some changes which, sadly, break compatibility with the older Hopper versions.

I'm not (yet) familiar with VC4, so I've left "instructionManipulatesFloat" without a proper implementation.